### PR TITLE
Updated Calculation of Epoch for Timestamp Param

### DIFF
--- a/HMSApiCore/Core.cs
+++ b/HMSApiCore/Core.cs
@@ -68,7 +68,7 @@ namespace com.healthmarketscience.api.samples.dotnet
             get
             {
                 return new Dictionary<string, string>() {
-                    { "timestamp",  (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond).ToString() },
+                    { "timestamp", ((long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds).ToString() },
                     { "key", DEFAULT_KEY }
                 };
             }


### PR DESCRIPTION
Using the previous calculation was not the correct way to obtain an epoch timestamp. Ticks are calculated as nanoseconds since 1/1/1 12:00 am.

This new calculation will properly calculate the number of milliseconds since 1/1/1970 12:00am
